### PR TITLE
ADD new url to ppe apps manager

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,10 +94,12 @@
                 <img src="assets/logo-jira.png">
             </div>
             <div class="grid-item">
-              <h2>Pipestat</h2>
+              <h2>Apps</h2>
                 <ul>
                     <li><a href="https://pipestat.ppxp.team/">Pipestat</a></li>
-                </ul>
+                    <li><a href="https://login.sc2-04-pcf1-system.oc.vmware.com/login">PPE Aps Manager</a></li>
+
+                  </ul>
                 <img src="assets/logo-pipestat.png" style="border-radius: 6px; border: 1px solid white;">
             </div>
             <div class="grid-item">


### PR DESCRIPTION
Added to ppxp.team main page a URL pointing to `PPE Apps Manager` to make it more discoverable for the team.

Co-authored-by: Marcela Lara <mlara@vmware.com>
Co-authored-by: Jhonathan Aristizabal <jhonathana@vmware.com>